### PR TITLE
Fix storage class attributes type definition

### DIFF
--- a/src/proxmox/Api/nodes/node/storage.php
+++ b/src/proxmox/Api/nodes/node/storage.php
@@ -26,7 +26,7 @@ class storage
      * @param $apiURL string
      * @param $cookie string
      */
-    public function __construct(Client $httpClient, string $apiURL, string $cookie)
+    public function __construct($httpClient, $apiURL, $cookie)
     {
         $this->httpClient = $httpClient; //Save the http client from GuzzleHttp in class variable
         $this->apiURL = $apiURL; //Save api url in class variable and change this to current api path
@@ -40,7 +40,7 @@ class storage
      * @param $storage string
      * @return storageId
      */
-    public function storageId(string $storage)
+    public function storageId($storage)
     {
         return new storageId($this->httpClient, $this->apiURL . $storage . '/', $this->cookie);
     }


### PR DESCRIPTION
Hello @MrKampf 

While coding on my website I detected an error related to the storage attributes class type.
Being specific with the `$cookie` parameter that seems to not be of `string` type. I though to fix it setting the valid type but, I saw that the other classes don't have type definition anyway.

Have a nice day, Regards!