### PR TITLE
API fix

### DIFF
--- a/src/Proxmox/Helper/Api.php
+++ b/src/Proxmox/Helper/Api.php
@@ -41,7 +41,7 @@ class Api
         try {
             return $this->getBody($this->PVE->getHttpClient()->request('GET', $this->PVE->getApiURL() . $path, [
                 'verify' => false,
-                'debug' => $this->PVE->getDebug(),
+                'debug' => $this->PVE->getDebug() ? fopen('php://stderr', 'w') : null,
                 'headers' => [
                     'CSRFPreventionToken' => $this->PVE->getCSRFPreventionToken(),
                     'Accept' => 'application/json',
@@ -79,7 +79,7 @@ class Api
         try {
             return $this->getBody($this->PVE->getHttpClient()->request('POST', $this->PVE->getApiURL() . $path, [
                 'verify' => false,
-                'debug' => $this->PVE->getDebug(),
+                'debug' => $this->PVE->getDebug() ? fopen('php://stderr', 'w') : null,
                 'headers' => [
                     'CSRFPreventionToken' => $this->PVE->getCSRFPreventionToken(),
                     'Content-Type' => (count($params) > 0) ? 'application/json' : null,
@@ -88,7 +88,7 @@ class Api
                 ],
                 'exceptions' => false,
                 'cookies' => $this->PVE->getCookie(),
-                'json' => $params,
+                'json' => (count($params) > 0) ? $params : null,
             ]));
         } catch (GuzzleException $exception) {
             if ($this->PVE->getDebug()) {
@@ -109,7 +109,7 @@ class Api
         try {
             return $this->getBody($this->PVE->getHttpClient()->request('PUT', $this->PVE->getApiURL() . $path, [
                 'verify' => false,
-                'debug' => $this->PVE->getDebug(),
+                'debug' => $this->PVE->getDebug() ? fopen('php://stderr', 'w') : null,
                 'headers' => [
                     'CSRFPreventionToken' => $this->PVE->getCSRFPreventionToken(),
                     'Content-Type' => (count($params) > 0) ? 'application/json' : null,
@@ -118,7 +118,7 @@ class Api
                 ],
                 'exceptions' => false,
                 'cookies' => $this->PVE->getCookie(),
-                'json' => $params,
+                'json' => (count($params) > 0) ? $params : null,
             ]));
         } catch (GuzzleException $exception) {
             if ($this->PVE->getDebug()) {
@@ -139,7 +139,7 @@ class Api
         try {
             return $this->getBody($this->PVE->getHttpClient()->request('DELETE', $this->PVE->getApiURL() . $path, [
                 'verify' => false,
-                'debug' => $this->PVE->getDebug(),
+                'debug' => $this->PVE->getDebug() ? fopen('php://stderr', 'w') : null,
                 'headers' => [
                     'CSRFPreventionToken' => $this->PVE->getCSRFPreventionToken(),
                     'Content-Type' => (count($params) > 0) ? 'application/json' : null,
@@ -178,7 +178,7 @@ class Api
         try {
             return $this->getBody($this->PVE->getHttpClient()->request('POST', $this->PVE->getApiURL() . 'access/ticket', [
                 'verify' => false,
-                'debug' => $this->PVE->getDebug(),
+                'debug' => $this->PVE->getDebug() ? fopen('php://stderr', 'w') : null,
                 'headers' => [
                     'Accept' => 'application/json',
                     'Accept-Encoding' => 'gzip',


### PR DESCRIPTION
According to the issue 13 specifically on the most recent comment https://github.com/MrKampf/proxmoxVE/issues/13#issuecomment-979774022
This seems to solve the issue ''cannot represent a stream of type Output as a STDIO FILE*'' and as well fixing the CSRF token occuring ''must be of type string, null given''. 
When testing I stumbled upon an issue according how the params are sent, it was already patched in the delete function I added these as well to post and put.

About the debug setting,
https://github.com/guzzle/guzzle/issues/1413