### PR TITLE
Get requests params

### DIFF
--- a/src/Proxmox/Api/Cluster/Resources.php
+++ b/src/Proxmox/Api/Cluster/Resources.php
@@ -27,11 +27,12 @@ class Resources extends PVEPathClassBase
     /**
      * Resources index (cluster wide).
      * @link https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/resources
+     * @params array $params
      * @return array|null
      */
-    public function get(): ?array
+    public function get($params = []): ?array
     {
-        return $this->getPve()->getApi()->get($this->getPathAdditional());
+        return $this->getPve()->getApi()->get($this->getPathAdditional(), $params);
     }
 
 }

--- a/src/Proxmox/Helper/Api.php
+++ b/src/Proxmox/Helper/Api.php
@@ -49,6 +49,7 @@ class Api
                 ],
                 'exceptions' => false,
                 'cookies' => $this->PVE->getCookie(),
+                'query' => $params
             ]));
         } catch (GuzzleException $exception) {
             if ($this->PVE->getDebug()) {


### PR DESCRIPTION
This PR adds globally optional `$params` supports for GET requests.

It also add support for optional `$params` in Resources.php `get` function.

You can now filter the type of resource you want to fetch, for example:

```
cluster()->resources()->get(['type' => 'node']);
```
