### PR TITLE
Fix migrate endpoint path + naming to match the PVE API (qemu + lxc)

### DIFF
--- a/src/Proxmox/Api/Nodes/Node/Lxc/VmId.php
+++ b/src/Proxmox/Api/Nodes/Node/Lxc/VmId.php
@@ -9,7 +9,7 @@ use Proxmox\Api\Nodes\Node\Lxc\VmId\CloneVm;
 use Proxmox\Api\Nodes\Node\Lxc\VmId\Config;
 use Proxmox\Api\Nodes\Node\Lxc\VmId\Feature;
 use Proxmox\Api\Nodes\Node\Lxc\VmId\Firewall;
-use Proxmox\Api\Nodes\Node\Lxc\VmId\Migration;
+use Proxmox\Api\Nodes\Node\Lxc\VmId\Migrate;
 use Proxmox\Api\Nodes\Node\Lxc\VmId\MoveVolume;
 use Proxmox\Api\Nodes\Node\Lxc\VmId\Pending;
 use Proxmox\Api\Nodes\Node\Lxc\VmId\Resize;
@@ -104,12 +104,12 @@ class VmId extends PVEPathClassBase
 
     /**
      * Migrate the container to another node. Creates a new migration task.
-     * @link https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc/{vmid}/migration
-     * @return Migration
+     * @link https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc/{vmid}/migrate
+     * @return Migrate
      */
-    public function migration(): Migration
+    public function migrate(): Migrate
     {
-        return new Migration($this->getPve(), $this->getPathAdditional());
+        return new Migrate($this->getPve(), $this->getPathAdditional());
     }
 
     /**

--- a/src/Proxmox/Api/Nodes/Node/Lxc/VmId/Migrate.php
+++ b/src/Proxmox/Api/Nodes/Node/Lxc/VmId/Migrate.php
@@ -10,10 +10,10 @@ use Proxmox\PVE;
 use Proxmox\API;
 
 /**
- * Class Migration
+ * Class Migrate
  * @package Proxmox\Api\Nodes\Node\Lxc\VmId
  */
-class Migration extends PVEPathClassBase
+class Migrate extends PVEPathClassBase
 {
     /**
      * Init constructor.
@@ -22,12 +22,12 @@ class Migration extends PVEPathClassBase
      */
     public function __construct(PVE|API $pve, string $parentAdditional)
     {
-        parent::__construct($pve, $parentAdditional . 'migration/');
+        parent::__construct($pve, $parentAdditional . 'migrate/');
     }
 
     /**
      * Migrate the container to another node. Creates a new migration task.
-     * @link https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc/{vmid}/migration
+     * @link https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc/{vmid}/migrate
      * @param array $params
      * @return array|null
      */

--- a/src/Proxmox/Api/Nodes/Node/Qemu/VmId.php
+++ b/src/Proxmox/Api/Nodes/Node/Qemu/VmId.php
@@ -11,7 +11,7 @@ use Proxmox\Api\Nodes\Node\Qemu\VmId\CloudInit;
 use Proxmox\Api\Nodes\Node\Qemu\VmId\Config;
 use Proxmox\Api\Nodes\Node\Qemu\VmId\Feature;
 use Proxmox\Api\Nodes\Node\Qemu\VmId\Firewall;
-use Proxmox\Api\Nodes\Node\Qemu\VmId\Migration;
+use Proxmox\Api\Nodes\Node\Qemu\VmId\Migrate;
 use Proxmox\Api\Nodes\Node\Qemu\VmId\Monitor;
 use Proxmox\Api\Nodes\Node\Qemu\VmId\MoveDisk;
 use Proxmox\Api\Nodes\Node\Qemu\VmId\Pending;
@@ -128,13 +128,13 @@ class VmId extends PVEPathClassBase
     }
 
     /**
-     * Migrate the container to another node. Creates a new migration task.
-     * @link https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/Qemu/{vmid}/migration
-     * @return Migration
+     * Migrate the virtual machine to another node. Creates a new migration task.
+     * @link https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/migrate
+     * @return Migrate
      */
-    public function migration(): Migration
+    public function migrate(): Migrate
     {
-        return new Migration($this->getPve(), $this->getPathAdditional());
+        return new Migrate($this->getPve(), $this->getPathAdditional());
     }
 
     /**

--- a/src/Proxmox/Api/Nodes/Node/Qemu/VmId/Migrate.php
+++ b/src/Proxmox/Api/Nodes/Node/Qemu/VmId/Migrate.php
@@ -10,10 +10,10 @@ use Proxmox\PVE;
 use Proxmox\API;
 
 /**
- * Class Migration
+ * Class Migrate
  * @package Proxmox\Api\Nodes\Node\Qemu\VmId
  */
-class Migration extends PVEPathClassBase
+class Migrate extends PVEPathClassBase
 {
     /**
      * Init constructor.
@@ -22,12 +22,12 @@ class Migration extends PVEPathClassBase
      */
     public function __construct(PVE|API $pve, string $parentAdditional)
     {
-        parent::__construct($pve, $parentAdditional . 'migration/');
+        parent::__construct($pve, $parentAdditional . 'migrate/');
     }
 
     /**
      * Get preconditions for migration.
-     * @link https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/migration
+     * @link https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/migrate
      * @param array $params
      * @return array|null
      */
@@ -37,8 +37,8 @@ class Migration extends PVEPathClassBase
     }
 
     /**
-     * Migrate the container to another node. Creates a new migration task.
-     * @link https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/migration
+     * Migrate the virtual machine to another node. Creates a new migration task.
+     * @link https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/migrate
      * @param array $params
      * @return array|null
      */


### PR DESCRIPTION
The qemu and lxc "migrate" resources were named `Migration` and built the
path segment `migration/`, but the Proxmox API exposes these endpoints at
`migrate` (`POST /nodes/{node}/qemu/{vmid}/migrate` and
`.../lxc/{vmid}/migrate` — see pve-container `src/PVE/API2/LXC.pm`,
`path => '{vmid}/migrate'`). The `migration/` path therefore 404s against
a live PVE node.

This renames `Migration` → `Migrate` (class + `VmId::migration()` →
`migrate()`) and corrects the path to `migrate/` for both qemu and lxc,
matching the path-segment naming used by every other resource class.
Also fixes a stray capital `Qemu` in the qemu `@link`.

**BC note:** `VmId::migration()` is renamed to `migrate()`. Callers using
the old name must update — happy to add a deprecated `migration()` alias
delegating to `migrate()` if you would prefer to keep it non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)